### PR TITLE
Update kids age threshold from 1 year to 3 months

### DIFF
--- a/client/pages/MainPage.tsx
+++ b/client/pages/MainPage.tsx
@@ -115,16 +115,16 @@ export default function MainPage() {
         const goats = activeAnimals.filter((animal) => animal.type === "goat");
         const sheep = activeAnimals.filter((animal) => animal.type === "sheep");
 
-        // Calculate kids (animals less than 1 year old)
+        // Calculate kids (animals less than 3 months old)
         const now = new Date();
-        const oneYearAgo = new Date(
-          now.getFullYear() - 1,
-          now.getMonth(),
+        const threeMonthsAgo = new Date(
+          now.getFullYear(),
+          now.getMonth() - 3,
           now.getDate(),
         );
         const kids = activeAnimals.filter((animal) => {
           if (!animal.dateOfBirth) return false;
-          return new Date(animal.dateOfBirth) > oneYearAgo;
+          return new Date(animal.dateOfBirth) > threeMonthsAgo;
         });
 
         setAnimalStats({
@@ -466,7 +466,7 @@ export default function MainPage() {
                       <div className="flex items-center space-x-2 text-purple-700 mb-1">
                         <Baby className="h-4 w-4" />
                         <span className="text-xs font-medium">
-                          Kids (&lt;1yr)
+                          Kids (&lt;3 months)
                         </span>
                       </div>
                       <div className="text-xl font-bold text-purple-800">


### PR DESCRIPTION
## Purpose

Update the Bija animal tracker to classify animals under 3 months old as "kids" instead of the previous 1-year threshold. This change provides a more accurate age categorization for young animals in the tracking system.

## Code changes

- Updated the kids calculation logic to use 3 months instead of 1 year as the age threshold
- Modified the date calculation from `oneYearAgo` to `threeMonthsAgo` using `getMonth() - 3`
- Updated the UI label from "Kids (<1yr)" to "Kids (<3 months)" to reflect the new classification
- Updated code comments to accurately describe the new 3-month threshold

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 8`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9f5ad60d5aca47eaa60338d1722549aa/flare-zone)

👀 [Preview Link](https://9f5ad60d5aca47eaa60338d1722549aa-flare-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9f5ad60d5aca47eaa60338d1722549aa</projectId>-->
<!--<branchName>flare-zone</branchName>-->