### PR TITLE
Fix breeding history refresh after adding birth records

### DIFF
--- a/client/components/BreedingManager.tsx
+++ b/client/components/BreedingManager.tsx
@@ -314,7 +314,7 @@ export default function BreedingManager({
 
       toast({
         title: "Birth Record Created Successfully! 🎉",
-        description: `Added ${formData.kids.length} kid${formData.kids.length !== 1 ? 's' : ''} to breeding history. ${newAnimalIds.length} new animal record${newAnimalIds.length !== 1 ? 's' : ''} created. Check the breeding history panel to see the new record.`,
+        description: `Added ${formData.kids.length} kid${formData.kids.length !== 1 ? "s" : ""} to breeding history. ${newAnimalIds.length} new animal record${newAnimalIds.length !== 1 ? "s" : ""} created. Check the breeding history panel to see the new record.`,
       });
 
       // Refresh breeding records and keep dialog open to show updated history
@@ -410,7 +410,8 @@ export default function BreedingManager({
               </h3>
               {breedingRecords.length > 0 && (
                 <Badge className="bg-pink-100 text-pink-800">
-                  {breedingRecords.length} record{breedingRecords.length !== 1 ? 's' : ''}
+                  {breedingRecords.length} record
+                  {breedingRecords.length !== 1 ? "s" : ""}
                 </Badge>
               )}
             </div>
@@ -490,12 +491,20 @@ export default function BreedingManager({
               <div className="flex items-start gap-2">
                 <span className="text-lg">🐰</span>
                 <div>
-                  <p className="font-semibold text-blue-800 mb-2">How to Add Birth Records:</p>
+                  <p className="font-semibold text-blue-800 mb-2">
+                    How to Add Birth Records:
+                  </p>
                   <ul className="text-sm space-y-1 text-gray-600">
                     <li>• Fill in the birth date (required)</li>
                     <li>• Click "Add Kid" for each offspring born</li>
-                    <li>• Check "Create animal record" to automatically add live kids to your livestock</li>
-                    <li>• The breeding history will update immediately after saving</li>
+                    <li>
+                      • Check "Create animal record" to automatically add live
+                      kids to your livestock
+                    </li>
+                    <li>
+                      • The breeding history will update immediately after
+                      saving
+                    </li>
                   </ul>
                 </div>
               </div>


### PR DESCRIPTION
## Purpose

The user needed to add birth records (rabbit icon) in the ANIMAL tracker from the "Add New Birth Record" section with additional information. However, after adding kids, the breeding history was not displaying the new records in the same popup, requiring users to close and reopen the dialog to see updates.

## Code changes

- **Added refresh functionality**: Implemented `refreshingHistory` state and modified `loadBreedingRecords()` to support refresh mode
- **Auto-refresh after submission**: Breeding history now automatically refreshes after successfully adding birth records, keeping the dialog open to show immediate updates
- **Enhanced UI feedback**: 
  - Added loading spinner specifically for history refresh operations
  - Improved success toast message with clearer feedback about created records
  - Added visual enhancements to the rabbit button with pink styling and tooltip
- **Better user guidance**: Enhanced the instruction panel with step-by-step guidance on how to add birth records
- **Visual improvements**: Added calendar icon and record count badge to the breeding history section

The breeding history now updates immediately after adding new birth records without requiring users to close and reopen the dialog.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fbbfd235a3b944079c4ce98661582d21/cosmos-studio)

👀 [Preview Link](https://fbbfd235a3b944079c4ce98661582d21-cosmos-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fbbfd235a3b944079c4ce98661582d21</projectId>-->
<!--<branchName>cosmos-studio</branchName>-->